### PR TITLE
Revert "Add max-width to top logo"

### DIFF
--- a/jekyll/_includes/top.html
+++ b/jekyll/_includes/top.html
@@ -1,7 +1,7 @@
     <div id="masthead" class="grid section section-open">
       <div class="unit one-third center-on-mobiles" style="text-align: center;">
         <a href="{{ site.url }}/">
-          <img src="/img/shadowlandslogo800.png" width="375" style="height: auto; max-width: 100%;">
+          <img src="/img/shadowlandslogo800.png" width="375" style="height: auto;">
         </a>
       </div>
       <div class="nav unit two-thirds hide-on-mobiles">


### PR DESCRIPTION
Reverts simulationcraft/simc-server#4

The idea of the fix was good, but it only restricts the image width to the images specified width.

To truly fix the underlying issue, the top section needs to be somehow better adjusted so that the logo section on the left takes up the max space it is allowed, which is I think 1 third of the top, and the menu & text need to be properly aligned on the right and take up their max space of the remaining 2 thirds.